### PR TITLE
feat: Test application without sprockets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on: push
 jobs:
   rspec:
-    name: "Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}"
+    name: "ruby:${{ matrix.ruby }} rails:${{ matrix.rails }} sprockets:${{ matrix.sprockets }}"
     runs-on: ubuntu-20.04
 
     strategy:
@@ -18,6 +18,9 @@ jobs:
           - "6.1"
           - "6.0"
           - "5.2"
+        sprockets:
+          - "on"
+          - "off"
         exclude:
           - ruby: "3.1"
             rails: "5.2"
@@ -29,6 +32,7 @@ jobs:
       BUNDLE_WITHOUT: development
       BUNDLE_JOBS: 4
       BUNDLE_RETRY: 3
+      SPROCKETS: ${{ matrix.sprockets }}
 
     steps:
       - uses: actions/checkout@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ---
 
 ### New
+* Test integration with a Rails application without sprockets
 * Add support for Rails 7.0 and Ruby 3.1
 
 ### Changes

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source 'https://rubygems.org'
 # Load gem's dependencies
 gemspec
 
-gem 'rails'
-gem 'sprockets-rails' # not included by default in Rails 7+
+gem 'rails', require: false
+gem 'sprockets-rails', require: false # not included by default in Rails 7+
 
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 5.2.0"
-gem "sprockets-rails"
+gem "sprockets-rails", require: false
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails", "~> 5.0"

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.0.0"
-gem "sprockets-rails"
+gem "sprockets-rails", require: false
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails", "~> 5.0"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
-gem "sprockets-rails"
+gem "sprockets-rails", require: false
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails", "~> 5.0"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
-gem "sprockets-rails"
+gem "sprockets-rails", require: false
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails", "~> 5.0"

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -4,7 +4,13 @@ require_relative 'boot'
 
 require 'rails'
 require 'action_controller/railtie'
-require 'sprockets/rails'
+
+if %w[0 off no false].include?(ENV['SPROCKETS'])
+  SPROCKETS = false
+else
+  require 'sprockets/rails'
+  SPROCKETS = true
+end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -20,17 +20,33 @@ RSpec.describe 'Plugin', type: :request do
     end
   end
 
-  it 'contains the passthrough resources from sprockets' do
-    doc.at('link#test4').tap do |node|
-      expect(node).to be_present
-      expect(node[:href]).to eq 'http://cdn.example.org/relroot/assets/application-6ac3c3354847833f406a96850b1712fa3588191cae65a9f68b1d4c7c2e960139.css'
-      expect(node[:integrity]).to be_blank
-    end
+  if SPROCKETS
+    it 'contains the passthrough resources from sprockets' do
+      doc.at('link#test4').tap do |node|
+        expect(node).to be_present
+        expect(node[:href]).to eq 'http://cdn.example.org/relroot/assets/application-6ac3c3354847833f406a96850b1712fa3588191cae65a9f68b1d4c7c2e960139.css'
+        expect(node[:integrity]).to be_blank
+      end
 
-    doc.at('script#test5').tap do |node|
-      expect(node).to be_present
-      expect(node[:src]).to eq 'http://cdn.example.org/relroot/assets/application-31d5c5a3accecb31cf2e14d71b9e2ff28609f3d45028700c7c4f067788b51d45.js'
-      expect(node[:integrity]).to be_blank
+      doc.at('script#test5').tap do |node|
+        expect(node).to be_present
+        expect(node[:src]).to eq 'http://cdn.example.org/relroot/assets/application-31d5c5a3accecb31cf2e14d71b9e2ff28609f3d45028700c7c4f067788b51d45.js'
+        expect(node[:integrity]).to be_blank
+      end
+    end
+  else
+    it 'contains the passthrough resources from static assets' do
+      doc.at('link#test4').tap do |node|
+        expect(node).to be_present
+        expect(node[:href]).to eq 'http://cdn.example.org/relroot/stylesheets/application.css'
+        expect(node[:integrity]).to be_blank
+      end
+
+      doc.at('script#test5').tap do |node|
+        expect(node).to be_present
+        expect(node[:src]).to eq 'http://cdn.example.org/relroot/javascripts/application.js'
+        expect(node[:integrity]).to be_blank
+      end
     end
   end
 


### PR DESCRIPTION
Add support and test variants for a Rails application without sprockets loaded at all. This is the "default" in Rails 7.0+.