### PR TITLE
chore: Update minimum to Ruby 3.1+ and Rails 7.0+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,27 +15,23 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
+          - "3.3"
           - "3.2"
           - "3.1"
-          - "3.0"
-          - "2.7"
         rails:
+          - "8.0"
+          - "7.2"
+          - "7.1"
           - "7.0"
-          - "6.1"
-          - "6.0"
-          - "5.2"
         variant:
           - ""
           - "no-sprockets"
         exclude:
-          - ruby: "3.2"
-            rails: "5.2"
-          - ruby: "3.1"
-            rails: "6.0"
-          - ruby: "3.1"
-            rails: "5.2"
-          - ruby: "3.0"
-            rails: "5.2"
+          - rails: "8.0"
+            ruby: "3.1"
+          - rails: "7.0"
+            ruby: "3.4"
 
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
@@ -66,7 +62,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: "3.4"
           bundler-cache: true
 
       - run: bundle exec rubocop --parallel --fail-level E

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,6 @@ inherit_gem:
   rubocop-config: default.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: "3.1"
   SuggestExtensions: False
   NewCops: enable

--- a/Appraisals
+++ b/Appraisals
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
+appraise 'rails-8.0' do
+  gem 'rails', '~> 8.0.0'
+  gem 'sqlite3', '~> 2.0'
+end
+
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.0'
+  gem 'sqlite3', '~> 2.0'
+end
+
+appraise 'rails-7.1' do
+  gem 'rails', '~> 7.1.0'
+  gem 'sqlite3', '~> 1.4'
+end
+
 appraise 'rails-7.0' do
   gem 'rails', '~> 7.0.0'
-  gem 'sqlite3', '~> 1.4'
-end
-
-appraise 'rails-6.1' do
-  gem 'rails', '~> 6.1.0'
-  gem 'sqlite3', '~> 1.4'
-end
-
-appraise 'rails-6.0' do
-  gem 'rails', '~> 6.0.0'
-  gem 'sqlite3', '~> 1.4'
-end
-
-appraise 'rails-5.2' do
-  gem 'rails', '~> 5.2.0'
   gem 'sqlite3', '~> 1.4'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Changes
 
+- Change minimum Ruby to 3.1 and minimum Rails to 7.0 (non-EOL)
+
 ### Fixes
 
 ### Breaks

--- a/Gemfile
+++ b/Gemfile
@@ -5,17 +5,15 @@ source 'https://rubygems.org'
 # Load gem's dependencies
 gemspec
 
-gem 'net-smtp', require: false # not bundled in Ruby 3.1+
 gem 'rails', require: false
 gem 'sprockets-rails', require: false # not included by default in Rails 7+
 gem 'sqlite3', require: false
 
 gem 'rake', '~> 13.0'
 gem 'rspec', '~> 3.0'
-gem 'rspec-rails', '~> 6.0'
+gem 'rspec-rails'
 
-gem 'pry'
-gem 'rubocop-config', github: 'jgraichen/rubocop-config', ref: 'v7', require: false
+gem 'rubocop-config', github: 'jgraichen/rubocop-config', tag: 'v13', require: false
 
 group :development do
   gem 'appraisal'

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,15 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "net-smtp", require: false
 gem "rails", "~> 7.0.0"
 gem "sprockets-rails", require: false
 gem "sqlite3", "~> 1.4"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails"
-gem "pry"
-gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v7", require: false
+gem "rubocop-config", github: "jgraichen/rubocop-config", tag: "v13", require: false
 
 group :development do
   gem "appraisal"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,15 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "net-smtp", require: false
-gem "rails", "~> 6.0.0"
+gem "rails", "~> 7.1.0"
 gem "sprockets-rails", require: false
 gem "sqlite3", "~> 1.4"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails"
-gem "pry"
-gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v7", require: false
+gem "rubocop-config", github: "jgraichen/rubocop-config", tag: "v13", require: false
 
 group :development do
   gem "appraisal"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -2,15 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "net-smtp", require: false
-gem "rails", "~> 5.2.0"
+gem "rails", "~> 7.2.0"
 gem "sprockets-rails", require: false
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.0"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails"
-gem "pry"
-gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v7", require: false
+gem "rubocop-config", github: "jgraichen/rubocop-config", tag: "v13", require: false
 
 group :development do
   gem "appraisal"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,15 +2,13 @@
 
 source "https://rubygems.org"
 
-gem "net-smtp", require: false
-gem "rails", "~> 6.1.0"
+gem "rails", "~> 8.0.0"
 gem "sprockets-rails", require: false
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", "~> 2.0"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rspec-rails"
-gem "pry"
-gem "rubocop-config", github: "jgraichen/rubocop-config", ref: "v7", require: false
+gem "rubocop-config", github: "jgraichen/rubocop-config", tag: "v13", require: false
 
 group :development do
   gem "appraisal"

--- a/lib/rails/assets/manifest/helper.rb
+++ b/lib/rails/assets/manifest/helper.rb
@@ -2,20 +2,22 @@
 
 module Rails::Assets::Manifest
   module Helper
-    URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}i.freeze
+    URI_REGEXP = %r{^[-a-z]+://|^(?:cid|data):|^//}i
 
     def path_to_asset(source, options)
       if (entry = ::Rails::Assets::Manifest.lookup(path_with_extname(source, options)))
-        # Directly return the entry src if it is a fully qualified URL. Otherwise,
-        # Rails will join the URL with `relative_url_root` and/or asset host.
+        # Directly return the entry src if it is a fully qualified URL.
+        # Otherwise, Rails will join the URL with `relative_url_root`
+        # and/or asset host.
         return entry.src if URI_REGEXP.match?(entry.src)
 
         if entry.src[0] == '/'
           # When the asset name starts with a slash, Rails will skip an
-          # additional lookup via `#compute_asset_path` and directly use the
-          # provided path. As we already have looked up the manifest entry here,
-          # we can pass the entry source, but only *if* it starts with a slash.
-          return super entry.src, options
+          # additional lookup via `#compute_asset_path` and directly use
+          # the provided path. As we already have looked up the manifest
+          # entry here, we can pass the entry source, but only *if* it
+          # starts with a slash.
+          return super(entry.src, options)
         end
       end
 
@@ -89,9 +91,9 @@ module Rails::Assets::Manifest
         if required.nil?
           entry = ::Rails::Assets::Manifest.lookup(path)
 
-          # Only if it is an asset from our manifest and there is an integrity
-          # we default to adding one
-          if entry && entry.integrity
+          # Only if it is an asset from our manifest and there is an
+          # integrity we default to adding one
+          if entry&.integrity
             next yield(source, {integrity: entry.integrity, crossorigin: 'anonymous', **kwargs})
           end
         end

--- a/rails-assets-manifest.gemspec
+++ b/rails-assets-manifest.gemspec
@@ -29,10 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) {|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
-  spec.add_dependency 'activesupport', '> 4.2'
-  spec.add_dependency 'railties', '> 4.2'
-
-  spec.add_development_dependency 'bundler'
+  spec.add_dependency 'activesupport', '> 7.0'
+  spec.add_dependency 'railties', '> 7.0'
 end

--- a/spec/rails/assets/manifest/manifest_spec.rb
+++ b/spec/rails/assets/manifest/manifest_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Rails::Assets::Manifest::Manifest do
     let(:payload) { {'app.js': {nosrc: true}} }
 
     it 'raises an error' do
-      expect { lookup }.to raise_error(::Rails::Assets::Manifest::ManifestInvalid)
+      expect { lookup }.to raise_error(Rails::Assets::Manifest::ManifestInvalid)
     end
   end
 
@@ -40,7 +40,7 @@ RSpec.describe Rails::Assets::Manifest::Manifest do
     context 'with unknown name' do
       subject(:entry) { manifest.lookup('missing.js') }
 
-      it { is_expected.to be nil }
+      it { is_expected.to be_nil }
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe Rails::Assets::Manifest::Manifest do
     context 'with unknown name' do
       subject(:entry) { manifest.lookup!('missing.js') }
 
-      it { expect { entry }.to raise_error(::Rails::Assets::Manifest::EntryMissing) }
+      it { expect { entry }.to raise_error(Rails::Assets::Manifest::EntryMissing) }
     end
   end
 


### PR DESCRIPTION
This commit removes support for all EOL Ruby and Rails versions.

The shared rubocop configuration is updated to v13 and linter warning are fixed. This includes non-backward compatible Ruby syntax changes.